### PR TITLE
feat: Add hiddify_urls.conf to cleanup.sh

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -19,6 +19,7 @@ rm -f /etc/init.d/hiddify
 echo "Removing files and directories from /root/..."
 rm -f /root/hiddify-conf.json
 rm -f /root/hiddify-openvpn-conf.json
+rm -f /root/hiddify_urls.conf
 rm -f /root/hiddify_watchdog.sh
 rm -f /root/hiddify_openvpn_watchdog.sh
 rm -f /root/update_subscriptions.sh

--- a/service/hiddify
+++ b/service/hiddify
@@ -101,9 +101,6 @@ remove_cron_job() {
 
 start() {
     echo "Starting Hiddify service..."
-    
-    cp -f /etc/init.d/update_subscriptions.sh /root/update_subscriptions.sh
-    chmod +x /root/update_subscriptions.sh
 
     if [ ! -f "$SERVICE_DIR/HiddifyCli" ]; then
         download_and_extract || return 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,21 +1,21 @@
 # Update opkg and install necessary packages
-# install kmod-tun for tunneling support
 opkg update
 opkg install coreutils-nohup curl wget jq
 
-# Copy configuration and watchdog script, overwriting if they exist
+# Copy configuration and ALL helper scripts to /root
 cp -f hiddify-conf.json /root/hiddify-conf.json
 cp -f hiddify-openvpn-conf.json /root/hiddify-openvpn-conf.json
-cp -f hiddify_urls.conf /root/hiddify_urls.conf
 cp -f hiddify_watchdog.sh /root/hiddify_watchdog.sh
 cp -f hiddify_openvpn_watchdog.sh /root/hiddify_openvpn_watchdog.sh
+cp -f update_subscriptions.sh /root/update_subscriptions.sh
 cp -f -R openvpn /root/openvpn
 
-# Make the watchdog script executable
+# Make the scripts in /root executable
 chmod +x /root/hiddify_watchdog.sh
 chmod +x /root/hiddify_openvpn_watchdog.sh
+chmod +x /root/update_subscriptions.sh
 
-# Copy service script, overwriting if it exists, and make it executable
+# Copy the main service script to init.d and make it executable
 cp -f service/hiddify /etc/init.d/hiddify
 chmod +x /etc/init.d/hiddify
 


### PR DESCRIPTION
This commit adds the `hiddify_urls.conf` file to the `cleanup.sh` script. This ensures that the file is removed when the cleanup script is run.