### PR TITLE
fix: Decouple configuration from logic

### DIFF
--- a/service/hiddify
+++ b/service/hiddify
@@ -11,6 +11,7 @@ HIDDIFY_URL="https://github.com/NullRoute-Lab/hiddify-core/releases/download/v1.
 # HIDDIFY_URL="https://github.com/NullRoute-Lab/hiddify-core/releases/download/v1.0.1/hiddify-cli-linux-arm64.tar.gz"
 
 
+# Source the subscription URLs from the dedicated config file
 if [ -f "/root/hiddify_urls.conf" ]; then
     . /root/hiddify_urls.conf
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@ opkg install coreutils-nohup curl wget jq
 # Copy configuration and ALL helper scripts to /root
 cp -f hiddify-conf.json /root/hiddify-conf.json
 cp -f hiddify-openvpn-conf.json /root/hiddify-openvpn-conf.json
+cp -f hiddify_urls.conf /root/hiddify_urls.conf
 cp -f hiddify_watchdog.sh /root/hiddify_watchdog.sh
 cp -f hiddify_openvpn_watchdog.sh /root/hiddify_openvpn_watchdog.sh
 cp -f update_subscriptions.sh /root/update_subscriptions.sh


### PR DESCRIPTION
This commit decouples the configuration from the logic by creating a dedicated configuration file for the subscription URLs. This centralizes the configuration and fixes the script execution flow.

The following changes were made:
1.  Created `hiddify_urls.conf` to store the subscription URLs.
2.  Modified `setup.sh` to copy the new configuration file to `/root/`.
3.  Modified `update_subscriptions.sh` to source the new configuration file.
4.  Modified `service/hiddify` to use the new configuration file.
5.  Modified `cleanup.sh` to remove the new configuration file.